### PR TITLE
ci(workflows): sync with fredrikaverpil/github

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: stale
+# https://github.com/actions/stale
+
+on:
+  schedule:
+    - cron: "0 7 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: "This issue has been open for **7 days** with no activity. Remove the stale label or add a comment or it will be closed in **3 days**."
+          stale-pr-message: "This PR has been open for **7 days** with no activity. Remove the stale label or add a comment or it will be closed in **3 days**."
+          close-issue-message: "This issue was closed because it has been stalled for 10 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
+          days-before-stale: 7
+          days-before-close: 3
+          exempt-pr-labels: dependencies,pinned
+          exempt-issue-labels: dependencies


### PR DESCRIPTION
This PR syncs the GitHub repo with CI workflows from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.

Project types detected: go