### PR TITLE
feat: show pwd before showing diff

### DIFF
--- a/internal/command/executor.go
+++ b/internal/command/executor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/fredrikaverpil/multipr/internal/log"
 )
@@ -20,8 +21,9 @@ type Result struct {
 }
 
 type Executor struct {
-	log   *log.Logger
-	debug bool
+	log         *log.Logger
+	debug       bool
+	outputMutex sync.Mutex
 }
 
 func NewExecutor(logger *log.Logger, debug bool) *Executor {

--- a/internal/command/git.go
+++ b/internal/command/git.go
@@ -35,7 +35,14 @@ func (e *Executor) GitResetHard(dir, branch string) error {
 }
 
 func (e *Executor) GitDiff(dir string) error {
-	_, err := e.Execute("git", []string{"diff", "--color=always", "--cached"}, WithDir(dir), WithTee())
+	e.outputMutex.Lock()
+	defer e.outputMutex.Unlock()
+
+	_, err := e.Execute("pwd", []string{}, WithDir(dir), WithTee())
+	if err != nil {
+		return fmt.Errorf("failed to show pwd: %w", err)
+	}
+	_, err = e.Execute("git", []string{"diff", "--color=always", "--cached"}, WithDir(dir), WithTee())
 	if err != nil {
 		return fmt.Errorf("failed to show diff: %w", err)
 	}


### PR DESCRIPTION
## Why?

It's difficult to know which repo a diff gets shown for.

## What?

Print the `pwd` prior to showing each diff.


