### PR TITLE
ci(workflows): sync with fredrikaverpil/github

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,9 +12,7 @@ on:
 jobs:
   vuln:
     uses: fredrikaverpil/github/.github/workflows/go-vuln.yml@main
-    secrets: inherit
   lint:
     uses: fredrikaverpil/github/.github/workflows/go-lint.yml@main
     with:
       config-source: golden-latest
-    secrets: inherit


### PR DESCRIPTION
This PR syncs the GitHub repo with CI workflows from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.

Project types detected: go