### PR TITLE
ci(workflows): sync with fredrikaverpil/github

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,6 +11,9 @@ jobs:
     outputs:
       matrix: ${{ steps.find-dirs.outputs.matrix }}
     steps:
+      - name: checkout repo
+        uses: actions/checkout@v4
+
       - name: find project directories
         id: find-dirs
         uses: fredrikaverpil/github/.github/actions/find-dirs@main


### PR DESCRIPTION
This PR syncs the GitHub repo with CI workflows from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.