### PR TITLE
ci(dependabot): sync with fredrikaverpil/github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,25 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
-    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "gomod"
+    directories: ["./tools"]
+    allow:
+      - dependency-type: indirect
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns: ["*"]
     labels:
       - "dependencies"
 
   - package-ecosystem: "gomod"
     directories:
       - .
-      - tools
     schedule:
       interval: "weekly"
       day: "monday"
@@ -26,6 +37,5 @@ updates:
       gomod-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR syncs the GitHub repo with a generated `dependabot.yml` from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.