### PR TITLE
ci(dependabot): sync with fredrikaverpil/github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
       interval: "weekly"
       day: "monday"
     groups:
-      github-actions:
+      go-tools:
         patterns: ["*"]
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR syncs the GitHub repo with a generated `dependabot.yml` from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.