### PR TITLE
ci(dependabot): sync with fredrikaverpil/github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,21 +15,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "gomod"
-    directories: ["./tools"]
-    allow:
-      - dependency-type: indirect
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    groups:
-      go-tools:
-        patterns: ["*"]
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "gomod"
-    directories:
-      - .
+    directories: ["."]
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
This PR syncs the GitHub repo with a generated `dependabot.yml` from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.